### PR TITLE
Support unit start after, restart mode and restart seconds Configuration

### DIFF
--- a/templates/systemd.j2
+++ b/templates/systemd.j2
@@ -1,6 +1,9 @@
 {{ ansible_managed | comment }}
 [Unit]
 Description={{ item.description }}
+{% if item.after is defined %}
+After={{ item.after }}
+{% endif %}
 
 [Service]
 {% if item.type is defined and item.type != "simple" %}
@@ -23,6 +26,12 @@ ExecStop={{ item.stop_command }}
 {% for key in item.environment_variables %}
 Environment={{ key }}={{ item.environment_variables[key] }}
 {% endfor %}
+{% endif %}
+{% if item.restart_mode is defined %}
+Restart={{ item.restart_mode }}
+{% endif %}
+{% if item.restart_seconds is defined %}
+RestartSec={{ item.restart_seconds }}
 {% endif %}
 
 [Install]


### PR DESCRIPTION
---
name: Support unit start after, restart mode and restart seconds
about: This will allow further customization to created services for the drectives
---

**Describe the change**
This allows one to define additional directives when creating a systemd service

[Unit]
After={{ item.after }}

[Service]
Restart={{ item.restart_mode }}
RestartSec= {{ item.restart_seconds }}

**Testing**
Creating a service when defining `{{ item.after }}`, `{{ item.restart_mode }}` and `{{ item.restart_seconds }}` and confirming these were defined in the service definition
