### PR TITLE
adding a syslog section

### DIFF
--- a/templates/systemd.j2
+++ b/templates/systemd.j2
@@ -39,6 +39,9 @@ RestartSec={{ item.restart_seconds }}
 {% if item.pidfile is defined %}
 PIDFile={{ item.pidfile }}
 {% endif %}
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier={{ item.name }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
---
name: Pull request
about: Add a SyslogIdentifier section in .service

---

**Describe the change**
Adding a syslog section, the syslog identifier is based on the servicename.
It solves the issue/new feature #4

**Testing**
Sorry i haven't find any available host to test this implementation in molecule. I've juste done copy/paste praying that i've not introduced syntax error. 
You will have to check if it works running the service and then typing for example : "journalctl -t tomcat"
Thanks 
