### PR TITLE
adding a syslog identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ This example is taken from `molecule/default/converge.yml` and is tested on each
 
   vars:
     _service_test_command:
-      default: /usr/bin/sleep
-      Alpine: /bin/sleep
-      Debian: /bin/sleep
-      Ubuntu-16: /bin/sleep
-      Ubuntu-18: /bin/sleep
+      default: /usr/bin/echo "Simple-Service is running" && /usr/bin/sleep
+      Alpine: /usr/bin/echo "Simple-Service is running" && /bin/sleep
+      Debian: /usr/bin/echo "Simple-Service is running" && /bin/sleep
+      Ubuntu-16: /usr/bin/echo "Simple-Service is running" && /bin/sleep
+      Ubuntu-18: /usr/bin/echo "Simple-Service is running" && /bin/sleep
     service_test_command: "{{ _service_test_command[ansible_distribution ~ '-' ~ ansible_distribution_major_version] | default(_service_test_command[ansible_os_family] | default(_service_test_command['default'])) }}"  # noqa 204 Just long.
 
   roles:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,11 +6,11 @@
 
   vars:
     _service_test_command:
-      default: /usr/bin/sleep
-      Alpine: /bin/sleep
-      Debian: /bin/sleep
-      Ubuntu-16: /bin/sleep
-      Ubuntu-18: /bin/sleep
+      default: /usr/bin/echo "Simple-Service is running" && /usr/bin/sleep
+      Alpine: /usr/bin/echo "Simple-Service is running" && /bin/sleep
+      Debian: /usr/bin/echo "Simple-Service is running" && /bin/sleep
+      Ubuntu-16: /usr/bin/echo "Simple-Service is running" && /bin/sleep
+      Ubuntu-18: /usr/bin/echo "Simple-Service is running" && /bin/sleep
     service_test_command: "{{ _service_test_command[ansible_distribution ~ '-' ~ ansible_distribution_major_version] | default(_service_test_command[ansible_os_family] | default(_service_test_command['default'])) }}"  # noqa 204 Just long.
 
   roles:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -28,3 +28,12 @@
       register: service_check_stopped_service
       failed_when:
         - service_check_stopped_service is changed
+
+    - name: get journalctl
+      ansible.builtin.command:
+        cmd: journalctl -t simple-service
+      register: journalctl_result
+
+    - name: check journalctl
+      assert:
+        that: "'Simple Service is running' in journalctl_result.stdout"

--- a/templates/systemd.j2
+++ b/templates/systemd.j2
@@ -39,6 +39,9 @@ RestartSec={{ item.restart_seconds }}
 {% if item.pidfile is defined %}
 PIDFile={{ item.pidfile }}
 {% endif %}
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier={{ item.name }}
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/systemd.j2
+++ b/templates/systemd.j2
@@ -39,8 +39,6 @@ RestartSec={{ item.restart_seconds }}
 {% if item.pidfile is defined %}
 PIDFile={{ item.pidfile }}
 {% endif %}
-StandardOutput=syslog
-StandardError=syslog
 SyslogIdentifier={{ item.name }}
 
 [Install]


### PR DESCRIPTION
---
name: Adding a Syslog identifier
about: make the log more readable, using journalctl- t <service-name> 

---

**Describe the change**
Adding a syslog identifier is based on the servicename.
It solves the issue/new feature https://github.com/robertdebock/ansible-role-service/issues/4

**Testing**
I was able to test on a centos 7, and i had a verify clause based on "journactl" command
